### PR TITLE
Remove pointers-to-pointers in batched matrix kernels

### DIFF
--- a/python/cuml/tsa/batched_lbfgs.py
+++ b/python/cuml/tsa/batched_lbfgs.py
@@ -2,7 +2,7 @@ import scipy.optimize as optimize
 import numpy as np
 from IPython.core.debugger import set_trace
 from scipy.optimize import _lbfgsb
-from cuml.ts.nvtx import pynvtx_range_push, pynvtx_range_pop
+from cuml.common.cuda import nvtx_range_push, nvtx_range_pop
 
 from collections import deque
 
@@ -61,7 +61,7 @@ def batched_fmin_lbfgs_b(func, x0, num_batches, fprime=None, args=(),
               Maximum number of line-search iterations.
     """
 
-    pynvtx_range_push("LBFGS")
+    nvtx_range_push("LBFGS")
     n = len(x0) // num_batches
 
     if fprime is None:
@@ -108,7 +108,7 @@ def batched_fmin_lbfgs_b(func, x0, num_batches, fprime=None, args=(),
     warn_flag = np.zeros(num_batches)
 
     while not all(converged):
-        pynvtx_range_push("LBFGS-ITERATION")
+        nvtx_range_push("LBFGS-ITERATION")
         for ib in range(num_batches):
             if converged[ib]:
                 continue
@@ -141,7 +141,7 @@ def batched_fmin_lbfgs_b(func, x0, num_batches, fprime=None, args=(),
                 warn_flag[ib] = 2
                 continue
 
-        pynvtx_range_pop()
+        nvtx_range_pop()
     xk = np.concatenate(x)
 
     if iprint > 0:
@@ -153,5 +153,5 @@ def batched_fmin_lbfgs_b(func, x0, num_batches, fprime=None, args=(),
                 if warn_flag[ib] > 0:
                     print("WARNING: id={} convergence issue: {}".format(ib, task[ib].tostring()))
 
-    pynvtx_range_pop()
+    nvtx_range_pop()
     return xk, n_iterations, warn_flag


### PR DESCRIPTION
See https://github.com/rapidsai/cuml/issues/1227

Pointers-to-pointers result in more global memory accesses and should therefore be avoided when possible. This PR changes them in the batched matrix kernels to a single pointer to the raw data. Also I formatted the doxygen documentations in this file properly.

Note:
 - I fixed the broken kronecker product implementation (cf my comment https://github.com/rapidsai/cuml/pull/1194#discussion_r337033581)
 - the wrong kronecker kernel tells that the testing was not sufficient. I can make the tests stronger in this PR or a new one if you agree.